### PR TITLE
Add proper description on home page

### DIFF
--- a/magasinscp/templates/index.html
+++ b/magasinscp/templates/index.html
@@ -26,11 +26,11 @@
                 <div class="col-md-5">
                     <h1><strong>Acheter rapidement sans délai</strong></h1>
                     <br>
-                    <p>Offrir aux élèves des occasions significatives de vivre le succès, de s'épanouir dans le respect
-                        de
-                        la diversité à travers un encadrement académique et un engagement social, afin qu'ils deviennent
-                        des
-                        citoyens du monde.</p><br>
+                    <p>Magasin SCP est une application web en ligne permettant de gérer vos étamps viking et d'acheter
+                        des articles. Les élèves peuvent créer un compte pour consulter leurs timbres et acheter les
+                        articles
+                        disponibles de manière simple et efficace, tandis que les enseignants peuvent gérer les timbres
+                        de leurs élèves et traiter leurs achats. </p><br>
                     <a href="{{ url_for('register')}}"><button type="button" style="color: white"
                             class="btn btn-warning btn-lg">Débuter</button></a>
                 </div>


### PR DESCRIPTION
Replaced placeholder text with a proper description of the home website on the home page.